### PR TITLE
Spotify docker-client version upgrade

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     compile(
-        'com.spotify:docker-client:5.0.2'
+        'com.spotify:docker-client:8.9.1'
     )
 
     compileOnly(


### PR DESCRIPTION
The current version uses an old version of Guava that is incompatible with projects relying on version 20 or above, although only for windows builds.