### PR TITLE
Support docker commands

### DIFF
--- a/core/src/main/java/com/shazam/tocker/DockerInstance.java
+++ b/core/src/main/java/com/shazam/tocker/DockerInstance.java
@@ -34,14 +34,16 @@ import static java.util.stream.Collectors.toMap;
 
 public class DockerInstance {
     private final String imageName;
+    private final String[] commands;
     private final String containerName;
     private final ImageStrategy imageStrategy;
     private HostConfig hostConfig;
     private String[] env;
     private DefaultDockerClient dockerClient;
 
-    private DockerInstance(String imageName, String containerName, HostConfig hostConfig, String[] env, ImageStrategy imageStrategy) {
+    private DockerInstance(String imageName, String[] commands, String containerName, HostConfig hostConfig, String[] env, ImageStrategy imageStrategy) {
         this.imageName = imageName;
+        this.commands = commands;
         this.containerName = containerName;
         this.hostConfig = hostConfig;
         this.env = env;
@@ -101,6 +103,7 @@ public class DockerInstance {
         ContainerConfig containerConfig = ContainerConfig.builder()
                 .image(imageName)
                 .hostConfig(hostConfig)
+                .cmd(commands)
                 .env(env)
                 .build();
         return dockerClient.createContainer(containerConfig, containerName);
@@ -117,6 +120,7 @@ public class DockerInstance {
     public static class DockerInstanceBuilder {
         private final ImageStrategy imageStrategy;
         private String imageName;
+        private String[] commands;
         private String containerName;
         private HostConfig.Builder hostConfig = HostConfig.builder();
         private String[] env;
@@ -132,7 +136,7 @@ public class DockerInstance {
         }
 
         public DockerInstance build() {
-            return new DockerInstance(imageName, containerName, hostConfig.build(), env, imageStrategy);
+            return new DockerInstance(imageName, commands, containerName, hostConfig.build(), env, imageStrategy);
         }
 
         public DockerInstanceBuilder withContainerName(String containerName) {
@@ -155,6 +159,11 @@ public class DockerInstance {
 
         public DockerInstanceBuilder withEnv(String ... env) {
             this.env = env;
+            return this;
+        }
+
+        public DockerInstanceBuilder withCommands(String ... commands) {
+            this.commands = commands;
             return this;
         }
     }

--- a/core/src/test/groovy/com/shazam/tocker/UsingADockerInstanceSpec.groovy
+++ b/core/src/test/groovy/com/shazam/tocker/UsingADockerInstanceSpec.groovy
@@ -112,11 +112,28 @@ class UsingADockerInstanceSpec extends Specification implements DockerDsl {
                 .withContainerName(containerNameFor("alive-check"))
                 .mappingPorts(PortMap.of(6379, 6380))
                 .build()
-            AliveStrategy aliveStrategy = new CapturingAliveStrategy();
+            AliveStrategy aliveStrategy = new CapturingAliveStrategy()
 
         expect:
             def returnedRunningInstance = instance.run(aliveStrategy)
             aliveStrategy.runningInstance == returnedRunningInstance
+    }
+    
+    def 'can pass through commands to the container on instantiation'() {
+        given:
+            def containerName = containerNameFor('image-commands')
+            def instance = DockerInstance
+                .fromImage("redis")
+                .withCommands('redis-cli')
+                .withContainerName(containerName)
+                .build()
+    
+        when:
+            instance.run()
+        
+        then:
+            client.inspectContainer(containerName).args() == ['redis-cli']
+    
     }
 
     class CapturingAliveStrategy implements AliveStrategy {


### PR DESCRIPTION
To be able to start images like `flink` that have a bunch of command options for how the image should run (`local`, `jobmanager`, `taskmanager`, etc) we need to be able to specify the `cmd` property in the `ContainerConfig` object.